### PR TITLE
Register $phpconsole as global before it is used.

### DIFF
--- a/phpconsole/install.php
+++ b/phpconsole/install.php
@@ -2,6 +2,7 @@
 
 include_once('phpconsole.php');
 
+global $phpconsole;
 $phpconsole = new Phpconsole();
 $phpconsole->set_backtrace_depth(1);
 


### PR DESCRIPTION
In my environment (PHP 5.3.16) I found that if I didn't make the change above I would get errors like this when I tried to use p()
FastCGI sent in stderr: "PHP message: PHP Fatal error:  Call to a member function send() on a non-object in ...
