### PR TITLE
Determine UUID after config has been loaded

### DIFF
--- a/src/Phpconsole/Config.php
+++ b/src/Phpconsole/Config.php
@@ -30,7 +30,6 @@ class Config implements LoggerInterface
     public function __construct()
     {
         $this->loadFromDefaultLocation();
-        $this->determineUUID();
     }
 
     public function log($message, $highlight = false)
@@ -110,6 +109,7 @@ class Config implements LoggerInterface
 
         $this->log('Config loaded from array into Config object');
 
+        $this->determineUUID();
         $this->determineDefaultProject();
 
         return true;


### PR DESCRIPTION
This is required because otherwise the UUID might be initiated before the config is loaded (if the config is not stored at a "default location". This would create a UUID cookie, even if it's disabled in the (not yet loaded) config.

Moving the `determineUUID();` call into the `loadFromArray()` function solves this because this is always called when the config is loaded.
